### PR TITLE
[gh11536] Added documentation for using parameters when generating a page

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -875,6 +875,7 @@ This also updates `Routes.js` in `./web/src`.
 | -------------------- | ------------------------------------------------------------------------------------ |
 | `name`               | Name of the page                                                                     |
 | `path`               | URL path to the page. Defaults to `name`                                             |
+| `parameters`         | Optional. Include the URL parameters when generating the page.                       |
 | `--force, -f`        | Overwrite existing files                                                             |
 | `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript |
 | `--tests`            | Generate test files [default: true]                                                  |

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -875,7 +875,7 @@ This also updates `Routes.js` in `./web/src`.
 | -------------------- | ------------------------------------------------------------------------------------ |
 | `name`               | Name of the page                                                                     |
 | `path`               | URL path to the page. Defaults to `name`                                             |
-| `parameters`         | Optional. Include the URL parameters when generating the page.                       |
+| `{parameters}`       | Optional. Include the URL parameters when generating the page.                       |
 | `--force, -f`        | Overwrite existing files                                                             |
 | `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript |
 | `--tests`            | Generate test files [default: true]                                                  |

--- a/docs/versioned_docs/version-8.1/cli-commands.md
+++ b/docs/versioned_docs/version-8.1/cli-commands.md
@@ -871,15 +871,15 @@ from `name` and the route parameter, if specified, will be added to the end.
 
 This also updates `Routes.js` in `./web/src`.
 
-| Arguments & Options  | Description                                                                           |
-| -------------------- | ------------------------------------------------------------------------------------- |
-| `name`               | Name of the page                                                                      |
-| `path`               | URL path to the page. Defaults to `name`                                              |
-| `--force, -f`        | Overwrite existing files                                                              |
-| `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript  |
-| `--tests`            | Generate test files [default: true]                                                   |
-| `--stories`          | Generate Storybook files [default: true]                                              |
-| `--rollback`         | Rollback changes if an error occurs [default: true]                                   |
+| Arguments & Options  | Description                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| `name`               | Name of the page                                                                     |
+| `path`               | URL path to the page. Defaults to `name`                                             |
+| `--force, -f`        | Overwrite existing files                                                             |
+| `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript |
+| `--tests`            | Generate test files [default: true]                                                  |
+| `--stories`          | Generate Storybook files [default: true]                                             |
+| `--rollback`         | Rollback changes if an error occurs [default: true]                                  |
 
 **Destroying**
 

--- a/docs/versioned_docs/version-8.1/cli-commands.md
+++ b/docs/versioned_docs/version-8.1/cli-commands.md
@@ -875,7 +875,6 @@ This also updates `Routes.js` in `./web/src`.
 | -------------------- | ------------------------------------------------------------------------------------- |
 | `name`               | Name of the page                                                                      |
 | `path`               | URL path to the page. Defaults to `name`                                              |
-| `WithParams`         | Include params for the route. Example: `yarn rw g page WithParams /with/{str:String}` |
 | `--force, -f`        | Overwrite existing files                                                              |
 | `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript  |
 | `--tests`            | Generate test files [default: true]                                                   |

--- a/docs/versioned_docs/version-8.1/cli-commands.md
+++ b/docs/versioned_docs/version-8.1/cli-commands.md
@@ -871,15 +871,16 @@ from `name` and the route parameter, if specified, will be added to the end.
 
 This also updates `Routes.js` in `./web/src`.
 
-| Arguments & Options  | Description                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------ |
-| `name`               | Name of the page                                                                     |
-| `path`               | URL path to the page. Defaults to `name`                                             |
-| `--force, -f`        | Overwrite existing files                                                             |
-| `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript |
-| `--tests`            | Generate test files [default: true]                                                  |
-| `--stories`          | Generate Storybook files [default: true]                                             |
-| `--rollback`         | Rollback changes if an error occurs [default: true]                                  |
+| Arguments & Options  | Description                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| `name`               | Name of the page                                                                      |
+| `path`               | URL path to the page. Defaults to `name`                                              |
+| `WithParams`         | Include params for the route. Example: `yarn rw g page WithParams /with/{str:String}` |
+| `--force, -f`        | Overwrite existing files                                                              |
+| `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript  |
+| `--tests`            | Generate test files [default: true]                                                   |
+| `--stories`          | Generate Storybook files [default: true]                                              |
+| `--rollback`         | Rollback changes if an error occurs [default: true]                                   |
 
 **Destroying**
 


### PR DESCRIPTION
Fixes #11536 

## Feature description

When generating a page with the command line, you can specify the route parameter when generating the page. For example:

```
yarn rw g page pageName {param}
```

## Solution description

This use case is already specified as example code within the documentation, but not listed within the table. With this update, the option is listed within the table.