### PR TITLE
chore(docs): background check documentation update

### DIFF
--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -165,7 +165,10 @@ These options allows you to disable the generation of test and story files.
 There are new versions of the framework all the time—a major every couple months, a minor every week or two, and patches when appropriate.
 And if you're on an experimental release line, like canary, there's new versions every day, multiple times.
 
-If you'd like to get notified (at most, once a day) when there's a new version, set `versionUpdates` to include the version tags you're interested in.
+If you'd like to get notified (at most, once a day) when there's a new version, set `versionUpdates` to an array of the version tags you're interested in (tags listed earlier take priority).
+While you can specify any tag, common options include: `latest`, `canary`, `next`, or `rc`.
+
+To opt out of background version checks entirely, simply remove the `versionUpdates` option, comment it out, or set its value to an empty array `[""]`.
 
 ## Using Environment Variables in `redwood.toml`
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -2279,10 +2279,12 @@ yarn redwood upgrade -t 0.19.3
 
 The CLI can check for things in the background, like new versions of the framework, while you dev.
 
-Right now it can only check for new versions.
-If you'd like it to do so, set `notifications.versionUpdates` in the `redwood.toml` file to include an array of the tags you're interested in hearing about.
-(The former has priority.)
+Right now it defaults to check for a new `latest` version.
+To customize this behavior - perhaps by checking for `rc` (release candidate) or other tags - set `notifications.versionUpdates` in the `redwood.toml` file to include an array of the tags you're interested in.
+Tags listed earlier in the array have priority.
 
-By default, the CLI won't check for upgrades—you have to opt into it.
+You can opt out of the background check process.
 
-You'll see this notification once a day at most. And the CLI will check for it once a day at most. So, nothing heavy-handed going on here.
+You'll see this notification once a day at most. And the CLI will check for an upgrade once a day, at most. So, nothing heavy-handed going on here.
+
+For more details, see the [TOML configuration section in the documentation](app-configuration-redwood-toml.md#cli).


### PR DESCRIPTION
Updated the documentation around automated background checks to reflect that it is 

- Default enabled
- Provided example tags that can be used: `latest`, `canary`, `next`, or `rc`
- Provided options for user to disable the automated check

This information spans two documents. Since the two documents interact, I added a link from the background check section to the TOML configuration section.