### PR TITLE
Handle path with whitespaces in build cmd

### DIFF
--- a/.changesets/11692.md
+++ b/.changesets/11692.md
@@ -1,0 +1,3 @@
+- Handle path with whitespaces in build cmd (#11692) by @callingmedic911
+
+Fixes an edge case where if the path to the project has whitespaces, the build command would fail.

--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -147,7 +147,7 @@ export const handler = async ({
 
     // Running a separate process here, otherwise it wouldn't pick up the
     // generated Prisma Client due to require module caching
-    await execa('yarn rw prerender', {
+    await execa('yarn', ['rw', 'prerender'], {
       stdio: 'inherit',
       cwd: rwjsPaths.web.base,
     })

--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -49,7 +49,6 @@ export const handler = async ({
         const { cmd, args } = generatePrismaCommand(rwjsPaths.api.dbSchema)
         return execa(cmd, args, {
           stdio: verbose ? 'inherit' : 'pipe',
-          shell: true,
           cwd: rwjsPaths.api.base,
         })
       },
@@ -103,12 +102,14 @@ export const handler = async ({
         // so that users don't have to see it when this command is called with --verbose
         process.env.VITE_CJS_IGNORE_WARNING = 'true'
         await execa(
-          `node ${require.resolve(
-            '@redwoodjs/vite/bins/rw-vite-build.mjs',
-          )} --webDir="${rwjsPaths.web.base}" --verbose=${verbose}`,
+          'node',
+          [
+            require.resolve('@redwoodjs/vite/bins/rw-vite-build.mjs'),
+            `--webDir=${path.resolve(rwjsPaths.web.base)}`,
+            `--verbose=${verbose}`,
+          ],
           {
             stdio: verbose ? 'inherit' : 'pipe',
-            shell: true,
             // `cwd` is needed for yarn to find the rw-vite-build binary
             // It won't change process.cwd for anything else here, in this
             // process
@@ -148,7 +149,6 @@ export const handler = async ({
     // generated Prisma Client due to require module caching
     await execa('yarn rw prerender', {
       stdio: 'inherit',
-      shell: true,
       cwd: rwjsPaths.web.base,
     })
   }

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -22,8 +22,12 @@ export const generatePrismaCommand = (schema) => {
   }
 
   return {
-    cmd: `node "${require.resolve('prisma/build/index.js')}"`,
-    args: ['generate', schema && `--schema="${schema}"`],
+    cmd: `node`,
+    args: [
+      require.resolve('prisma/build/index.js'),
+      'generate',
+      schema && `--schema=${schema}`,
+    ],
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/11464.

- We could have either quoted the path so it's properly passed as an argument OR we don't use `shell: true` and let execa deal with it on its own. I went with the latter. 
- I realized we probably don't need `shell: true` at other places in this file. (we probably don't need `shell: true` in other commands too, but trying not to creep up the scope of this PR)