### PR TITLE
[feature] Add a storybook theme switcher to the Toolbar for Chakra UI

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
@@ -30,7 +30,7 @@ export function builder(yargs) {
 
 const CHAKRA_THEME_AND_COMMENTS = `\
 // This object will be used to override Chakra-UI theme defaults.
-// See https://chakra-ui.com/docs/styled-system/theming/theme for theming options
+// See https://v2.chakra-ui.com/docs/styled-system/theme for theming options
 const theme = {}
 export default theme
 `

--- a/packages/cli/src/commands/setup/ui/templates/chakra.storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/ui/templates/chakra.storybook.preview.tsx.template
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { ChakraProvider, extendTheme, useColorMode } from '@chakra-ui/react'
 import type { GlobalTypes } from '@storybook/csf'
 import type { Preview, StoryContext, StoryFn } from '@storybook/react'
+
 import theme from 'config/chakra.config'
 
 const extendedTheme = extendTheme(theme)
@@ -31,7 +32,7 @@ const ColorModeSwitch = ({ colorMode }: { colorMode: 'light' | 'dark' }) => {
 }
 
 const withChakra = (Story: StoryFn, context: StoryContext) => {
-  theme.config.initialColorMode = context.globals.theme // avoids flash on reload for non-default color mode
+  extendedTheme.config.initialColorMode = context.globals.theme // avoids flash on reload for non-default color mode
   return (
     <ChakraProvider theme={extendedTheme}>
       <ColorModeSwitch colorMode={context.globals.theme} />

--- a/packages/cli/src/commands/setup/ui/templates/chakra.storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/ui/templates/chakra.storybook.preview.tsx.template
@@ -1,20 +1,48 @@
 import * as React from 'react'
 
-import { ChakraProvider, extendTheme } from '@chakra-ui/react'
-import type { Preview, StoryFn } from '@storybook/react'
+import { ChakraProvider, extendTheme, useColorMode } from '@chakra-ui/react'
+import type { GlobalTypes } from '@storybook/csf'
+import type { Preview, StoryContext, StoryFn } from '@storybook/react'
 import theme from 'config/chakra.config'
 
 const extendedTheme = extendTheme(theme)
 
-/** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} */
-const withChakra = (Story: StoryFn) => (
-  <ChakraProvider theme={extendedTheme}>
-    <Story />
-  </ChakraProvider>
-)
+/** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#global-types-and-the-toolbar-annotation | Global types and the toolbar annotation}  */
+const globalTypes: GlobalTypes = {
+  theme: {
+    description: 'Theme',
+    defaultValue: 'dark',
+    toolbar: {
+      dynamicTitle: true,
+      icon: 'contrast',
+      items: [
+        { value: 'dark', left: '🌜', title: 'Dark mode' },
+        { value: 'light', left: '🌞', title: 'Light mode' },
+      ],
+    },
+  },
+}
+
+const ColorModeSwitch = ({ colorMode }: { colorMode: 'light' | 'dark' }) => {
+  const { setColorMode } = useColorMode()
+  React.useEffect(() => setColorMode(colorMode), [colorMode, setColorMode])
+
+  return <></>
+}
+
+const withChakra = (Story: StoryFn, context: StoryContext) => {
+  theme.config.initialColorMode = context.globals.theme // avoids flash on reload for non-default color mode
+  return (
+    <ChakraProvider theme={extendedTheme}>
+      <ColorModeSwitch colorMode={context.globals.theme} />
+      <Story />
+    </ChakraProvider>
+  )
+}
 
 const preview: Preview = {
-  decorators: [withChakra]
+  decorators: [withChakra],
+  globalTypes,
 }
 
 export default preview


### PR DESCRIPTION
This PR adds a button to the storybook toolbar that enables to switch between dark and light color mode in Chakra UI:

![grafik](https://github.com/user-attachments/assets/491e37f1-8822-4204-ba25-616daa146543)

![grafik](https://github.com/user-attachments/assets/5ec6ebec-095f-4d0f-86e9-96018b40e619)

Actually i've been searching a solution how to do this for quite some time as i never got the official `@chakra-ui/storybook-addon` to work – and as it relies on webpack it won't ever work with the storybook+vite default since Redwood 8.

Thanks heaps to @simoncrypta for contributing the i18n language switcher, which ultimately pointed me in the right direction when i looked at the [preview.tsx template](https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template) for that.