### PR TITLE
[Docs] Fix "Where does redwood load my environment variables?" code & link

### DIFF
--- a/docs/versioned_docs/version-8.4/environment-variables.md
+++ b/docs/versioned_docs/version-8.4/environment-variables.md
@@ -137,16 +137,16 @@ yarn-error.log
 
 For all the variables in your `.env` and `.env.defaults` files to make their way to `process.env`, there has to be a call to `dotenv`'s `config` function somewhere. So where is it?
 
-It's in [the CLI](https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/index.js#L6-L12)&mdash;every time you run a `yarn rw` command:
+It's in [the CLI](https://github.com/redwoodjs/redwood/blob/v8.4.2/packages/cli/src/lib/loadEnvFiles.js#L38-L44)&mdash;every time you run a `yarn rw` command:
 
-```jsx title="packages/cli/src/index.js"
-import { config } from 'dotenv-defaults'
-
-config({
-  path: path.join(getPaths().base, '.env'),
-  encoding: 'utf8',
-  defaults: path.join(getPaths().base, '.env.defaults'),
-})
+```jsx title="packages/cli/src/lib/loadEnvFiles.js"
+export function loadDefaultEnvFiles(cwd) {
+  dotenvDefaultsConfig({
+    path: path.join(cwd, '.env'),
+    defaults: path.join(cwd, '.env.defaults'),
+    multiline: true,
+  })
+}
 ```
 
 Remember, if `yarn rw dev` is already running, your local app won't reflect any changes you make to your `.env` file until you stop and re-run `yarn rw dev`.

--- a/docs/versioned_docs/version-8.4/environment-variables.md
+++ b/docs/versioned_docs/version-8.4/environment-variables.md
@@ -137,10 +137,10 @@ yarn-error.log
 
 For all the variables in your `.env` and `.env.defaults` files to make their way to `process.env`, there has to be a call to `dotenv`'s `config` function somewhere. So where is it?
 
-It's in [the CLI](https://github.com/redwoodjs/redwood/blob/v8.4.2/packages/cli/src/lib/loadEnvFiles.js#L38-L44)&mdash;every time you run a `yarn rw` command:
+It's in [the CLI](https://github.com/redwoodjs/redwood/blob/v8.4.2/packages/cli-helpers/src/lib/loadEnvFiles.ts#L35-L43)&mdash;every time you run a `yarn rw` command:
 
-```jsx title="packages/cli/src/lib/loadEnvFiles.js"
-export function loadDefaultEnvFiles(cwd) {
+```ts title="packages/cli/src/lib/loadEnvFiles.js"
+export function loadDefaultEnvFiles(cwd: string) {
   dotenvDefaultsConfig({
     path: path.join(cwd, '.env'),
     defaults: path.join(cwd, '.env.defaults'),


### PR DESCRIPTION
This is a work in progress. 

I was researching the docs to find out how to set up a dedicated `.env.test` for a [prisma test environment](https://www.prisma.io/docs/orm/prisma-client/testing/integration-testing) on our CI and found the link in that section linking to outdated code.

Only by looking at the code i discovered the `--load-env-files` option – i shall add a little section on this if it enables what i hope it does.