### PR TITLE
fix: install corepack from npm

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,7 @@ tasks:
       export REDWOOD_DISABLE_TELEMETRY=1
     init: |
       cd /workspace/redwood
-      corepack enable
+      npm i -g corepack
       yarn install
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
       cd /workspace/rw-test-app && sed -i "s/\(open *= *\).*/\1false/" redwood.toml


### PR DESCRIPTION
Corepack is not going to be distributed with Node.js v25+
TSC vote https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616

This PR updates the command to globally installing corepack.