### PR TITLE
fix(cli): Tell yarn not to install Tailwind types (they're deprecated)

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -24,7 +24,7 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.3",
+    "postcss": "^8.5.6",
     "postcss-loader": "^8.1.1",
     "prettier-plugin-tailwindcss": "^0.5.12",
     "tailwindcss": "^3.4.17"

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -171,6 +171,11 @@ export const handler = async ({ force, install }) => {
                     ['workspace', 'web', 'add', '-D', ...webWorkspacePackages],
                     {
                       cwd: rwPaths.base,
+                      env: {
+                        // See https://github.com/cedarjs/cedar/pull/152 for
+                        // context
+                        YARN_TS_ENABLE_AUTO_TYPES: 'false',
+                      },
                     },
                   )
                 },


### PR DESCRIPTION
For some reason [@types](https://github.com/types)`/tailwindcss` started getting installed when setting up TW. Those types are deprecated and should not be included.

See [https://github.com/cedarjs/cedar/pull/152](https://github.com/cedarjs/cedar/pull/152) for more context