### PR TITLE
fix(api-server): handle path names with 'graphql'

### DIFF
--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../plugins/lambdaLoader'
 
 // Suppress terminal logging.
-console.log = vi.fn()
+// console.log = vi.fn()
 console.warn = vi.fn()
 
 // Set up RWJS_CWD.
@@ -56,10 +56,12 @@ describe('loadFunctionsFromDist', () => {
   // We have logic that specifically puts the graphql function at the front.
   // Though it's not clear why or if this is actually respected by how JS objects work.
   // See the complementary lambdaLoaderNumberFunctions test.
-  it('puts the graphql function first', async () => {
+  it.only('puts the graphql function first', async () => {
     expect(LAMBDA_FUNCTIONS).toEqual({})
 
     await loadFunctionsFromDist()
+
+    console.log('LAMBDA_FUNCTIONS', LAMBDA_FUNCTIONS)
 
     expect(Object.keys(LAMBDA_FUNCTIONS)[0]).toEqual('graphql')
   })

--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -56,7 +56,7 @@ describe('loadFunctionsFromDist', () => {
   // We have logic that specifically puts the graphql function at the front.
   // Though it's not clear why or if this is actually respected by how JS objects work.
   // See the complementary lambdaLoaderNumberFunctions test.
-  it.only('puts the graphql function first', async () => {
+  it('puts the graphql function first', async () => {
     expect(LAMBDA_FUNCTIONS).toEqual({})
 
     await loadFunctionsFromDist()

--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../plugins/lambdaLoader'
 
 // Suppress terminal logging.
-// console.log = vi.fn()
+console.log = vi.fn()
 console.warn = vi.fn()
 
 // Set up RWJS_CWD.
@@ -60,8 +60,6 @@ describe('loadFunctionsFromDist', () => {
     expect(LAMBDA_FUNCTIONS).toEqual({})
 
     await loadFunctionsFromDist()
-
-    console.log('LAMBDA_FUNCTIONS', LAMBDA_FUNCTIONS)
 
     expect(Object.keys(LAMBDA_FUNCTIONS)[0]).toEqual('graphql')
   })

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -65,18 +65,11 @@ export const loadFunctionsFromDist = async (
     options?.fastGlobOptions,
   )
 
-  console.log('serverFunctions', serverFunctions)
-
   // Place `GraphQL` serverless function at the start.
   const i = serverFunctions.findIndex((x) => x.endsWith('graphql.js'))
-
-  console.log('found graphql.js at index', i)
-
   if (i >= 0) {
     const graphQLFn = serverFunctions.splice(i, 1)[0]
     serverFunctions.unshift(graphQLFn)
-
-    console.log('serverFunctions after splice and unshift', serverFunctions)
   }
 
   await setLambdaFunctions(serverFunctions)

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -68,11 +68,17 @@ export const loadFunctionsFromDist = async (
   console.log('serverFunctions', serverFunctions)
 
   // Place `GraphQL` serverless function at the start.
-  const i = serverFunctions.findIndex((x) => x.includes('graphql'))
+  const i = serverFunctions.findIndex((x) => x.endsWith('graphql.js'))
+
+  console.log('found graphql.js at index', i)
+
   if (i >= 0) {
     const graphQLFn = serverFunctions.splice(i, 1)[0]
     serverFunctions.unshift(graphQLFn)
+
+    console.log('serverFunctions after splice and unshift', serverFunctions)
   }
+
   await setLambdaFunctions(serverFunctions)
 }
 

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -65,6 +65,8 @@ export const loadFunctionsFromDist = async (
     options?.fastGlobOptions,
   )
 
+  console.log('serverFunctions', serverFunctions)
+
   // Place `GraphQL` serverless function at the start.
   const i = serverFunctions.findIndex((x) => x.includes('graphql'))
   if (i >= 0) {


### PR DESCRIPTION
When this repo changed name from 'redwood' to 'graphql' GitHub also changed the path for the project on its runners. With the new repo name the paths look like this:

```js
serverFunctions: [
  '/home/runner/work/graphql/graphql/packages/api-server/src/__tests__/fixtures/redwood-app/api/dist/functions/env.js',
  '/home/runner/work/graphql/graphql/packages/api-server/src/__tests__/fixtures/redwood-app/api/dist/functions/graphql.js',
  '/home/runner/work/graphql/graphql/packages/api-server/src/__tests__/fixtures/redwood-app/api/dist/functions/health.js',
  '/home/runner/work/graphql/graphql/packages/api-server/src/__tests__/fixtures/redwood-app/api/dist/functions/hello.js',
  '/home/runner/work/graphql/graphql/packages/api-server/src/__tests__/fixtures/redwood-app/api/dist/functions/noHandler.js',
  '/home/runner/work/graphql/graphql/packages/api-server/src/__tests__/fixtures/redwood-app/api/dist/functions/nested/nested.js'
]
```

Previously the code was looking for paths that included `'graphql'` to find the graphql function. The problem is that the paths now all include `'graphql'`. So this PR changes the code to look for paths that ends with `'graphql.js'` to find the graphql function