### PR TITLE
chore(ci): Update path to match new repo name

### DIFF
--- a/.github/actions/telemetry_check/check.mjs
+++ b/.github/actions/telemetry_check/check.mjs
@@ -51,7 +51,7 @@ try {
         process.exit(1)
       }
       exitCode = await exec(
-        `yarn --cwd ../project-for-telemetry node ../redwood/packages/cli/dist/index.js info`,
+        `yarn --cwd ../project-for-telemetry node ../graphql/packages/cli/dist/index.js info`,
       )
       if (exitCode) {
         process.exit(1)


### PR DESCRIPTION
The relative path is now `../graphql/` instead of `../redwood/` because the name of this repo changed