### PR TITLE
feat(api-server): lambdaLoader: add discoverfunctionsGlob option...

### DIFF
--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -176,12 +176,14 @@ Example usage after using a bundler that changes the directory structure, and ge
 ```ts
 const server = await createServer({
   logger,
-  fastifyServerOptions: { /*...*/ },
+  fastifyServerOptions: {
+    /*...*/
+  },
   discoverfunctionsGlob: [
     'app/functions/**/*.js',
     // exclude all *.2.js files, e.g: exclude `app/functions/graphql/graphql2.js`, but keep `app/functions/graphql/graphql.js`
     '!app/functions/**/*2.js',
-  ]
+  ],
 })
 ```
 

--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -69,7 +69,7 @@ Not updating the command will not completely configure the GraphQL Server and no
 
 ### Configuring the server
 
-There are three ways you may wish to configure the server.
+There are four ways you may wish to configure the server.
 
 #### Underlying Fastify server
 
@@ -162,6 +162,28 @@ The regular expression (`/^image\/.*/`) above allows all image content or MIME t
 Now, when you POST those content types to a function served by the api server, you can access the file content on `event.body`.
 
 Note that for the GraphQL endpoint, using Redwood's built-in [Uploads](uploads.md), multipart requests are already configured.
+
+#### discoverFunctionsGlob
+
+Third, you can configure the discovery of the Redwood function files with `discoverFunctionsGlob` when the default value (`dist/functions/**/*.{ts,js}`) is not suitable.
+
+The 3rd party library [fast-glob](https://github.com/mrmlnc/fast-glob) is used, which uses `https://github.com/micromatch/micromatch` under the covers. This allows configuring a single or multiple positive and negative matches.
+
+##### Example
+
+Example usage after using a bundler that changes the directory structure, and generates extra support files when converting from ES modules to CJS:
+
+```ts
+const server = await createServer({
+  logger,
+  fastifyServerOptions: { /*...*/ },
+  discoverfunctionsGlob: [
+    'app/functions/**/*.js',
+    // exclude all *.2.js files, e.g: exclude `app/functions/graphql/graphql2.js`, but keep `app/functions/graphql/graphql.js`
+    '!app/functions/**/*2.js',
+  ]
+})
+```
 
 #### Additional Fastify plugins
 

--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -179,7 +179,7 @@ const server = await createServer({
   fastifyServerOptions: {
     /*...*/
   },
-  discoverfunctionsGlob: [
+  discoverFunctionsGlob: [
     'app/functions/**/*.js',
     // exclude all *.2.js files, e.g: exclude `app/functions/graphql/graphql2.js`, but keep `app/functions/graphql/graphql.js`
     '!app/functions/**/*2.js',

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -16,6 +16,7 @@ import type { MockInstance } from 'vitest'
 import { getConfig } from '@redwoodjs/project-config'
 
 import type { createServer as tCreateServer } from '../createServer.js'
+import type { ResolvedOptions } from '../createServerHelpers'
 import {
   resolveOptions,
   DEFAULT_CREATE_SERVER_OPTIONS,
@@ -235,9 +236,11 @@ describe('resolveOptions', () => {
         logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
         bodyLimit: DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.bodyLimit,
       },
+      discoverfunctionsGlob:
+        DEFAULT_CREATE_SERVER_OPTIONS.discoverfunctionsGlob,
       apiPort: 65501,
       apiHost: '::',
-    })
+    } as ResolvedOptions)
   })
 
   it('ensures `apiRootPath` has slashes', () => {

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -236,8 +236,8 @@ describe('resolveOptions', () => {
         logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
         bodyLimit: DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.bodyLimit,
       },
-      discoverfunctionsGlob:
-        DEFAULT_CREATE_SERVER_OPTIONS.discoverfunctionsGlob,
+      discoverFunctionsGlob:
+        DEFAULT_CREATE_SERVER_OPTIONS.discoverFunctionsGlob,
       apiPort: 65501,
       apiHost: '::',
     } as ResolvedOptions)

--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -82,4 +82,55 @@ describe('loadFunctionsFromDist', () => {
       'does not have a function called handler defined.',
     )
   })
+
+  describe('when "discoverfunctionsGlob" is set', () => {
+    it('loads the same functions as the default value', async () => {
+      expect(LAMBDA_FUNCTIONS).toEqual({})
+
+      await loadFunctionsFromDist({
+        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+      })
+
+      expect(LAMBDA_FUNCTIONS).toEqual({
+        env: expect.any(Function),
+        graphql: expect.any(Function),
+        health: expect.any(Function),
+        hello: expect.any(Function),
+        nested: expect.any(Function),
+      })
+    })
+
+    it('loads functions when discoverfunctionsGlob is an array', async () => {
+      expect(LAMBDA_FUNCTIONS).toEqual({})
+
+      await loadFunctionsFromDist({
+        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+      })
+
+      expect(LAMBDA_FUNCTIONS).toEqual({
+        env: expect.any(Function),
+        graphql: expect.any(Function),
+        health: expect.any(Function),
+        hello: expect.any(Function),
+        nested: expect.any(Function),
+      })
+    })
+
+    it('loads functions when discoverfunctionsGlob has include and exclude values', async () => {
+      expect(LAMBDA_FUNCTIONS).toEqual({})
+
+      await loadFunctionsFromDist({
+        discoverfunctionsGlob: [
+          'dist/functions/**/*.{ts,js}',
+          '!dist/functions/**/he*.{ts,js}',
+        ],
+      })
+
+      expect(LAMBDA_FUNCTIONS).toEqual({
+        env: expect.any(Function),
+        graphql: expect.any(Function),
+        nested: expect.any(Function),
+      })
+    })
+  })
 })

--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -83,12 +83,12 @@ describe('loadFunctionsFromDist', () => {
     )
   })
 
-  describe('when "discoverfunctionsGlob" is set', () => {
+  describe('when "discoverFunctionsGlob" is set', () => {
     it('loads the same functions as the default value', async () => {
       expect(LAMBDA_FUNCTIONS).toEqual({})
 
       await loadFunctionsFromDist({
-        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+        discoverFunctionsGlob: ['dist/functions/**/*.{ts,js}'],
       })
 
       expect(LAMBDA_FUNCTIONS).toEqual({
@@ -100,11 +100,11 @@ describe('loadFunctionsFromDist', () => {
       })
     })
 
-    it('loads functions when discoverfunctionsGlob is an array', async () => {
+    it('loads functions when discoverFunctionsGlob is an array', async () => {
       expect(LAMBDA_FUNCTIONS).toEqual({})
 
       await loadFunctionsFromDist({
-        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+        discoverFunctionsGlob: ['dist/functions/**/*.{ts,js}'],
       })
 
       expect(LAMBDA_FUNCTIONS).toEqual({
@@ -116,11 +116,11 @@ describe('loadFunctionsFromDist', () => {
       })
     })
 
-    it('loads functions when discoverfunctionsGlob has include and exclude values', async () => {
+    it('loads functions when discoverFunctionsGlob has include and exclude values', async () => {
       expect(LAMBDA_FUNCTIONS).toEqual({})
 
       await loadFunctionsFromDist({
-        discoverfunctionsGlob: [
+        discoverFunctionsGlob: [
           'dist/functions/**/*.{ts,js}',
           '!dist/functions/**/he*.{ts,js}',
         ],

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -67,6 +67,7 @@ export async function createServer(options: CreateServerOptions = {}) {
   const {
     apiRootPath,
     fastifyServerOptions,
+    discoverfunctionsGlob,
     configureApiServer,
     apiPort,
     apiHost,
@@ -119,6 +120,7 @@ export async function createServer(options: CreateServerOptions = {}) {
       fastGlobOptions: {
         ignore: ['**/dist/functions/graphql.js'],
       },
+      discoverfunctionsGlob,
       configureServer: configureApiServer,
     },
   })

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -67,7 +67,7 @@ export async function createServer(options: CreateServerOptions = {}) {
   const {
     apiRootPath,
     fastifyServerOptions,
-    discoverfunctionsGlob,
+    discoverFunctionsGlob,
     configureApiServer,
     apiPort,
     apiHost,
@@ -120,7 +120,7 @@ export async function createServer(options: CreateServerOptions = {}) {
       fastGlobOptions: {
         ignore: ['**/dist/functions/graphql.js'],
       },
-      discoverfunctionsGlob,
+      discoverFunctionsGlob,
       configureServer: configureApiServer,
     },
   })

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -37,7 +37,7 @@ export interface CreateServerOptions {
    * Override the glob used to discover functions.
    * Defaults to: "dist/functions/**\/*.{ts,js}"
    */
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 
   /**
    * Customise the API server fastify plugin before it is registered
@@ -67,7 +67,7 @@ export const DEFAULT_CREATE_SERVER_OPTIONS: DefaultCreateServerOptions = {
     requestTimeout: 15_000,
     bodyLimit: 1024 * 1024 * 100, // 100MB
   },
-  discoverfunctionsGlob: 'dist/functions/**/*.{ts,js}',
+  discoverFunctionsGlob: 'dist/functions/**/*.{ts,js}',
   configureApiServer: () => {},
   parseArgs: true,
 }
@@ -99,9 +99,9 @@ export function resolveOptions(
       logger: options.logger ?? DEFAULT_CREATE_SERVER_OPTIONS.logger,
       bodyLimit: DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.bodyLimit,
     },
-    discoverfunctionsGlob:
-      options.discoverfunctionsGlob ??
-      DEFAULT_CREATE_SERVER_OPTIONS.discoverfunctionsGlob,
+    discoverFunctionsGlob:
+      options.discoverFunctionsGlob ??
+      DEFAULT_CREATE_SERVER_OPTIONS.discoverFunctionsGlob,
     configureApiServer:
       options.configureApiServer ??
       DEFAULT_CREATE_SERVER_OPTIONS.configureApiServer,

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -34,6 +34,12 @@ export interface CreateServerOptions {
   fastifyServerOptions?: Omit<FastifyServerOptions, 'logger'>
 
   /**
+   * Override the glob used to discover functions.
+   * Defaults to: "dist/functions/**\/*.{ts,js}"
+   */
+  discoverfunctionsGlob?: string | string[]
+
+  /**
    * Customise the API server fastify plugin before it is registered
    */
   configureApiServer?: (server: Server) => void | Promise<void>
@@ -61,11 +67,12 @@ export const DEFAULT_CREATE_SERVER_OPTIONS: DefaultCreateServerOptions = {
     requestTimeout: 15_000,
     bodyLimit: 1024 * 1024 * 100, // 100MB
   },
+  discoverfunctionsGlob: 'dist/functions/**/*.{ts,js}',
   configureApiServer: () => {},
   parseArgs: true,
 }
 
-type ResolvedOptions = Required<
+export type ResolvedOptions = Required<
   Omit<CreateServerOptions, 'logger' | 'fastifyServerOptions' | 'parseArgs'> & {
     fastifyServerOptions: FastifyServerOptions
     apiPort: number
@@ -92,6 +99,9 @@ export function resolveOptions(
       logger: options.logger ?? DEFAULT_CREATE_SERVER_OPTIONS.logger,
       bodyLimit: DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.bodyLimit,
     },
+    discoverfunctionsGlob:
+      options.discoverfunctionsGlob ??
+      DEFAULT_CREATE_SERVER_OPTIONS.discoverfunctionsGlob,
     configureApiServer:
       options.configureApiServer ??
       DEFAULT_CREATE_SERVER_OPTIONS.configureApiServer,

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -16,7 +16,7 @@ export interface RedwoodFastifyAPIOptions {
   redwood: {
     apiRootPath?: string
     fastGlobOptions?: FastGlobOptions
-    discoverfunctionsGlob?: string | string[]
+    discoverFunctionsGlob?: string | string[]
     loadUserConfig?: boolean
     configureServer?: (server: Server) => void | Promise<void>
   }
@@ -66,6 +66,6 @@ export async function redwoodFastifyAPI(
   fastify.all(`${redwoodOptions.apiRootPath}:routeName/*`, lambdaRequestHandler)
   await loadFunctionsFromDist({
     fastGlobOptions: redwoodOptions.fastGlobOptions,
-    discoverfunctionsGlob: redwoodOptions.discoverfunctionsGlob,
+    discoverFunctionsGlob: redwoodOptions.discoverFunctionsGlob,
   })
 }

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -16,6 +16,7 @@ export interface RedwoodFastifyAPIOptions {
   redwood: {
     apiRootPath?: string
     fastGlobOptions?: FastGlobOptions
+    discoverfunctionsGlob?: string | string[]
     loadUserConfig?: boolean
     configureServer?: (server: Server) => void | Promise<void>
   }
@@ -65,5 +66,6 @@ export async function redwoodFastifyAPI(
   fastify.all(`${redwoodOptions.apiRootPath}:routeName/*`, lambdaRequestHandler)
   await loadFunctionsFromDist({
     fastGlobOptions: redwoodOptions.fastGlobOptions,
+    discoverfunctionsGlob: redwoodOptions.discoverfunctionsGlob,
   })
 }

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -54,16 +54,18 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
 
 type LoadFunctionsFromDistOptions = {
   fastGlobOptions?: FastGlobOptions
+  discoverfunctionsGlob?: string | string[]
 }
 
 // TODO: Use v8 caching to load these crazy fast.
 export const loadFunctionsFromDist = async (
   options: LoadFunctionsFromDistOptions = {},
 ) => {
-  const serverFunctions = findApiDistFunctions(
-    getPaths().api.base,
-    options?.fastGlobOptions,
-  )
+  const serverFunctions = findApiDistFunctions({
+    cwd: getPaths().api.base,
+    options: options?.fastGlobOptions,
+    discoverfunctionsGlob: options?.discoverfunctionsGlob,
+  })
 
   // Place `GraphQL` serverless function at the start.
   const i = serverFunctions.findIndex((x) => x.endsWith('graphql.js'))
@@ -77,11 +79,17 @@ export const loadFunctionsFromDist = async (
 
 // NOTE: Copied from @redwoodjs/internal/dist/files to avoid depending on @redwoodjs/internal.
 // import { findApiDistFunctions } from '@redwoodjs/internal/dist/files'
-function findApiDistFunctions(
-  cwd: string = getPaths().api.base,
-  options: FastGlobOptions = {},
-) {
-  return fg.sync('dist/functions/**/*.{ts,js}', {
+const findApiDistFunctions = (params: {
+  cwd: string
+  options?: FastGlobOptions
+  discoverfunctionsGlob?: string | string[]
+}) => {
+  const {
+    cwd = getPaths().api.base,
+    options = {},
+    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+  } = params
+  return fg.sync(discoverfunctionsGlob, {
     cwd,
     deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
     absolute: true,

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -54,7 +54,7 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
 
 type LoadFunctionsFromDistOptions = {
   fastGlobOptions?: FastGlobOptions
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 }
 
 // TODO: Use v8 caching to load these crazy fast.
@@ -64,7 +64,7 @@ export const loadFunctionsFromDist = async (
   const serverFunctions = findApiDistFunctions({
     cwd: getPaths().api.base,
     options: options?.fastGlobOptions,
-    discoverfunctionsGlob: options?.discoverfunctionsGlob,
+    discoverFunctionsGlob: options?.discoverFunctionsGlob,
   })
 
   // Place `GraphQL` serverless function at the start.
@@ -82,14 +82,14 @@ export const loadFunctionsFromDist = async (
 const findApiDistFunctions = (params: {
   cwd: string
   options?: FastGlobOptions
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 }) => {
   const {
     cwd = getPaths().api.base,
     options = {},
-    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+    discoverFunctionsGlob = 'dist/functions/**/*.{ts,js}',
   } = params
-  return fg.sync(discoverfunctionsGlob, {
+  return fg.sync(discoverFunctionsGlob, {
     cwd,
     deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
     absolute: true,

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -106,14 +106,14 @@ export const findApiServerFunctions = (
 export const findApiDistFunctions = (params: {
   cwd: string
   options?: FastGlobOptions
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 }) => {
   const {
     cwd = getPaths().api.base,
     options = {},
-    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+    discoverFunctionsGlob = 'dist/functions/**/*.{ts,js}',
   } = params
-  return fg.sync(discoverfunctionsGlob, {
+  return fg.sync(discoverFunctionsGlob, {
     cwd,
     deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
     absolute: true,

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import fg from 'fast-glob'
+import fg, { type Options as FastGlobOptions } from 'fast-glob'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -99,11 +99,25 @@ export const findApiServerFunctions = (
   return files.filter((f) => isApiFunction(f, cwd))
 }
 
-export const findApiDistFunctions = (cwd: string = getPaths().api.base) => {
-  return fg.sync('dist/functions/**/*.{ts,js}', {
+/*
+ * There is a copy of this function in packages/api-server/src/plugins/lambdaLoader.ts
+ * This is done to avoid to avoid @redwoodjs/api-server depending on @redwoodjs/internal
+ */
+export const findApiDistFunctions = (params: {
+  cwd: string
+  options?: FastGlobOptions
+  discoverfunctionsGlob?: string | string[]
+}) => {
+  const {
+    cwd = getPaths().api.base,
+    options = {},
+    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+  } = params
+  return fg.sync(discoverfunctionsGlob, {
     cwd,
     deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
     absolute: true,
+    ...options,
   })
 }
 


### PR DESCRIPTION
for function discovery in createServer and related modules.

Allows overriding the glob used to discover functions, which is required when a different bundler is used, or the directory structure is not the default `dist/functions/`
* Defaults to: "dist/functions/**\/*.{ts,js}"
