### PR TITLE
docs(links): fix links to graphql repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Deployment URL: https://redwoodjs.com/docs
 
 ## Getting started
 
-Checkout this repo [(redwoodjs/redwood)](https://github.com/redwoodjs/redwood), `cd` into this directory (`docs`)
+Checkout this repo [(redwoodjs/redwood)](https://github.com/redwoodjs/graphql), `cd` into this directory (`docs`)
 
 ```
 yarn install
@@ -40,4 +40,4 @@ To update any images in the doc, first upload your screenshot into a comment tex
 
 ## Contributors
 
-Redwood is amazing thanks to a wonderful [community of contributors](https://github.com/redwoodjs/redwood/blob/main/README.md#contributors).
+Redwood is amazing thanks to a wonderful [community of contributors](https://github.com/redwoodjs/graphql/blob/main/README.md#contributors).

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -49,7 +49,7 @@ const config: Config = {
       logo: {
         alt: 'RedwoodJS pinecone logo',
         src: 'https://d33wubrfki0l68.cloudfront.net/72b0d56596a981835c18946d6c4f8a968b08e694/82254/images/logo.svg',
-        href: 'https://docs.redwoodjs.com/',
+        href: '/docs/',
         target: '_self',
       },
       items: [
@@ -58,7 +58,7 @@ const config: Config = {
           position: 'left',
         },
         {
-          href: 'https://github.com/redwoodjs/redwood',
+          href: 'https://github.com/redwoodjs/graphql',
           position: 'right',
           className: 'github-logo',
           'aria-label': 'GitHub repository',
@@ -106,7 +106,7 @@ const config: Config = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/redwoodjs/redwood',
+              href: 'https://github.com/redwoodjs/graphql',
             },
           ],
         },
@@ -121,7 +121,7 @@ const config: Config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // ? — blob? tree?
-          editUrl: 'https://github.com/redwoodjs/redwood/blob/main/docs', // base path for repo edit pages
+          editUrl: 'https://github.com/redwoodjs/graphql/blob/main/docs', // base path for repo edit pages
           editCurrentVersion: true,
           remarkPlugins: [autoImportTabs, fileExtSwitcher],
           versions: {


### PR DESCRIPTION
Fix links to point to the current URL of this repo: https://github.com/redwoodjs/graphql

I extracted this out of https://github.com/redwoodjs/graphql/pull/12047