### PR TITLE
fix(tui): validate spinner.characters (≥2) and frameInterval (>0); add first tests

### DIFF
--- a/packages/tui/src/index.test.ts
+++ b/packages/tui/src/index.test.ts
@@ -1,0 +1,26 @@
+/// <reference types="@types/jest" />
+
+import { ReactiveTUIContent } from './index'
+
+describe('ReactiveTUIContent validation', () => {
+  it('throws if spinner.characters has fewer than 2 entries', () => {
+    const r = new ReactiveTUIContent({})
+    expect(() =>
+      r.update({ spinner: { enabled: true, characters: ['-'] } }),
+    ).toThrow(/at least 2/i)
+  })
+
+  it('throws if frameInterval is 0 or negative', () => {
+    const r = new ReactiveTUIContent({})
+    expect(() => r.update({ frameInterval: 0 })).toThrow(/frameInterval.*> 0/i)
+    expect(() => r.update({ frameInterval: -5 })).toThrow(/frameInterval.*> 0/i)
+  })
+
+  it('accepts valid spinner.characters and frameInterval', () => {
+    const r = new ReactiveTUIContent({})
+    expect(() =>
+      r.update({ spinner: { enabled: true, characters: ['-', '\\'] } }),
+    ).not.toThrow()
+    expect(() => r.update({ frameInterval: 50 })).not.toThrow()
+  })
+})

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -66,9 +66,33 @@ export class ReactiveTUIContent {
         RedwoodStyling.redwood(c),
       ),
     }
+
+    // Validate spinner.characters if provided
+    if (
+      options.spinner?.characters !== undefined &&
+      (!Array.isArray(options.spinner.characters) ||
+        options.spinner.characters.length < 2)
+    ) {
+      throw new Error(
+        'tui: `spinner.characters` must be an array with at least 2 entries',
+      )
+    }
+
     this.spinner = { ...defaultSpinner, ...options.spinner }
     this.boxen = { ...options.boxen }
-    this.frameInterval = options.frameInterval || 80
+
+    // Validate frameInterval if provided
+    if (options.frameInterval !== undefined) {
+      if (
+        typeof options.frameInterval !== 'number' ||
+        options.frameInterval <= 0
+      ) {
+        throw new Error('tui: `frameInterval` must be a number > 0')
+      }
+      this.frameInterval = options.frameInterval
+    } else {
+      this.frameInterval = 80
+    }
 
     if (options.outStream) {
       this.setOutStream(options.outStream)
@@ -97,7 +121,16 @@ export class ReactiveTUIContent {
       this.content = options.content
     }
     if (options.spinner) {
-      // TODO: Validate characters array has at least two characters
+      // Validate characters array has at least two characters (if provided)
+      if (
+        options.spinner.characters !== undefined &&
+        (!Array.isArray(options.spinner.characters) ||
+          options.spinner.characters.length < 2)
+      ) {
+        throw new Error(
+          'tui: `spinner.characters` must be an array with at least 2 entries',
+        )
+      }
       this.spinner = { ...this.spinner, ...options.spinner }
     }
     if (options.boxen) {
@@ -106,8 +139,14 @@ export class ReactiveTUIContent {
     if (options.outStream) {
       this.setOutStream(options.outStream)
     }
-    if (options.frameInterval) {
-      // TODO: Validate > 0
+    if (options.frameInterval !== undefined) {
+      // Validate > 0
+      if (
+        typeof options.frameInterval !== 'number' ||
+        options.frameInterval <= 0
+      ) {
+        throw new Error('tui: `frameInterval` must be a number > 0')
+      }
       this.frameInterval = options.frameInterval
     }
   }
@@ -161,17 +200,19 @@ export class ReactiveTUIContent {
 }
 
 /**
- * Configuration for the TUI
+ * RedwoodTUI
  *
- * Accepts an out and err stream which the TUI will write to.
- */
-export interface RedwoodTUIConfig {
-  out?: NodeJS.WriteStream
-  err?: NodeJS.WriteStream
-}
-
-/**
- * TODO: Documentation for this
+ * A thin wrapper around stdout/stderr that renders static text and
+ * "reactive" content (e.g., spinners) to the terminal. It coordinates a
+ * shared UpdateManager, handles TTY/non-TTY output, and provides helpers
+ * for prompting and boxed messages.
+ *
+ * Typical usage:
+ *   const tui = new RedwoodTUI()
+ *   const content = new ReactiveTUIContent({ spinner: { enabled: true } })
+ *   tui.startReactive(content)
+ *   // ...work...
+ *   tui.stopReactive(true)
  */
 export class RedwoodTUI {
   private manager: UpdateManager
@@ -358,4 +399,14 @@ export class RedwoodTUI {
       }),
     )
   }
+}
+
+/**
+ * Configuration for the TUI
+ *
+ * Accepts an out and err stream which the TUI will write to.
+ */
+export interface RedwoodTUIConfig {
+  out?: NodeJS.WriteStream
+  err?: NodeJS.WriteStream
 }


### PR DESCRIPTION
Implements two small TODOs in packages/tui/src/index.ts:

- Enforce `spinner.characters` to be an array with ≥2 entries.
- Enforce `frameInterval` to be a number > 0.

Adds the first tests for the TUI package in `packages/tui/src/index.test.ts`
(valid + invalid cases). No behavior changes for valid inputs.